### PR TITLE
Avoid external url open to pass app store review

### DIFF
--- a/Sources/GithubAPI/GithubAuthorization.swift
+++ b/Sources/GithubAPI/GithubAuthorization.swift
@@ -10,20 +10,10 @@ import Ikemen
 import OAuthSwift
 
 internal class GithubAuthorization {
-    // Becasue OAuthSwift default url handler is not working on iOS 11,
-    // custom version is created here.
-    private class OpenURL: OAuthSwiftURLHandlerType {
-        func handle(_ url: URL) {
-            UIApplication.shared.open(url, options: [:], completionHandler: { _ in
-                ()
-            })
-        }
-    }
-
     // store as member field to prevent GC remove this before authorization process complete.
     private let oauth: OAuth2Swift
 
-    init() {
+    init(viewController: UIViewController) {
         oauth = OAuth2Swift(
             consumerKey: "dbcd395d464652fb1dc3",
             consumerSecret: "3574b156263a04f59903b9ec418e215d52e8590d",
@@ -32,7 +22,7 @@ internal class GithubAuthorization {
             responseType: "token",
             contentType: "application/json"
         ) ※ {
-            $0.authorizeURLHandler = OpenURL()
+            $0.authorizeURLHandler = SafariURLHandler(viewController: viewController, oauthSwift: $0)
         }
     }
 

--- a/Sources/OctoEye/Controller/LoginViewController.swift
+++ b/Sources/OctoEye/Controller/LoginViewController.swift
@@ -12,7 +12,9 @@ import UIKit
 
 internal class LoginViewController: UIViewController {
     private let loginButton: UIButton = UIButton(type: .system)
-    private let authorization: GithubAuthorization = GithubAuthorization()
+    private lazy var authorization: GithubAuthorization = {
+        GithubAuthorization(viewController: self)
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/OctoEye/Controller/LoginViewController.swift
+++ b/Sources/OctoEye/Controller/LoginViewController.swift
@@ -44,7 +44,10 @@ internal class LoginViewController: UIViewController {
             .observeResult { result in
                 switch result {
                 case .success(let credential):
-                    Authentication.accessToken = credential.oauthToken
+                    guard let oauthToken = credential?.oauthToken else {
+                        return
+                    }
+                    Authentication.accessToken = oauthToken
                     DispatchQueue.main.async {
                         self.present(MainNavigationViewController(), animated: true) {}
                     }

--- a/Sources/OctoEye/Controller/LoginViewController.swift
+++ b/Sources/OctoEye/Controller/LoginViewController.swift
@@ -12,9 +12,7 @@ import UIKit
 
 internal class LoginViewController: UIViewController {
     private let loginButton: UIButton = UIButton(type: .system)
-    private lazy var authorization: GithubAuthorization = {
-        GithubAuthorization(viewController: self)
-    }()
+    private let authorization: GithubAuthorization = GithubAuthorization()
 
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
Guideline 4.0 - Design


We noticed that the user is taken to Safari to sign in or register for an account, which provides a poor user experience.

Next Steps

To resolve this issue, please revise your app to enable users to sign in or register for an account in the app.

We recommend implementing the Safari View Controller API to display web content within your app. The Safari View Controller allows the display of a URL and inspection of the certificate from an embedded browser in an app so that customers can verify the webpage URL and SSL certificate to confirm they are entering their sign in credentials into a legitimate page.

Resources

For additional information on the Safari View Controller API, please review the What's New in Safari webpage.